### PR TITLE
Improve template and store rfcs in `rfcs` folder

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -7,81 +7,82 @@
 
 ## Summary
 
-Brief explanation of the feature.
+> Brief explanation of the feature.
 
 ## Basic example
 
-If the proposal involves a new or changed API, include a basic code example.
-Omit this section if it's not applicable.
+> If the proposal involves a new or changed API, include a basic code example.
+> Omit this section if it's not applicable.
 
 ## Motivation
 
-Why are we doing this? What use cases does it support? What is the expected
-outcome?
-
-Please focus on explaining the motivation so that if this RFC is not accepted,
-the motivation could be used to develop alternative solutions. In other words,
-enumerate the constraints you are trying to solve without coupling them too
-closely to the solution you have in mind.
-
-Please provide specific examples. If you say "this would be more flexible" then
-give an example of something that becomes easier. If you say "this would be make
-it easier to do X" then give an example of what that looks like today and what's
-hard about it.
-
-Don't assume that others recognize the problem is one that needs to be solved.
-Is there some concrete issue you cannot accomplish without this? What does it
-look like to accomplish some set of goals today and how could that be improved?
-Are there any workarounds that are necessary today? Are there open issues on
-Github where people would be helped by this?
+> Why are we doing this? What use cases does it support? What is the expected
+> outcome?
+>
+> Please focus on explaining the motivation so that if this RFC is not accepted,
+> the motivation could be used to develop alternative solutions. In other words,
+> enumerate the constraints you are trying to solve without coupling them too
+> closely to the solution you have in mind.
+>
+> Please provide specific examples. If you say "this would be more flexible"
+> then give an example of something that becomes easier. If you say "this would
+> be make it easier to do X" then give an example of what that looks like today
+> and what's hard about it.
+>
+> Don't assume that others recognize the problem is one that needs to be solved.
+> Is there some concrete issue you cannot accomplish without this? What does it
+> look like to accomplish some set of goals today and how could that be
+> improved? Are there any workarounds that are necessary today? Are there open
+> issues on Github where people would be helped by this?
 
 ## Detailed design
 
-This is the bulk of the RFC. Explain the design in enough detail for somebody
-familiar with Preact to understand, and for somebody familiar with the
-implementation to implement. This should get into specifics and corner-cases,
-and include examples of how the feature is used. Any new terminology should be
-defined here.
+> This is the bulk of the RFC. Explain the design in enough detail for somebody
+> familiar with Preact to understand, and for somebody familiar with the
+> implementation to implement. This should get into specifics and corner-cases,
+> and include examples of how the feature is used. Any new terminology should be
+> defined here.
 
 ## Drawbacks
 
-Why should we *not* do this? Please consider:
-
-- implementation cost, both in term of code size, performance, and complexity
-- whether the proposed feature can be implemented in user space
-- the impact on teaching people Preact
-- integration of this feature with other existing and planned features
-- cost of migrating existing Preact applications (is it a breaking change?)
-
-There are tradeoffs to choosing any path. Attempt to identify them here.
+> Why should we _not_ do this? Please consider:
+>
+> - implementation cost, both in term of code size, performance, and complexity
+> - whether the proposed feature can be implemented in user space
+> - the impact on teaching people Preact
+> - integration of this feature with other existing and planned features
+> - cost of migrating existing Preact applications (is it a breaking change?)
+>
+> There are tradeoffs to choosing any path. Attempt to identify them here.
 
 ## Alternatives
 
-What other designs have been considered? What is the impact of not doing this?
-
-This section could also include prior art, that is, how other frameworks in the
-same domain have solved this problem similarly or differently.
+> What other designs have been considered? What is the impact of not doing this?
+>
+> This section could also include prior art, that is, how other frameworks in
+> the same domain have solved this problem similarly or differently.
 
 ## Adoption strategy
 
-If we implement this proposal, how will existing Preact developers adopt it? Is
-this a breaking change? Can we write a codemod? Can we provide a runtime adapter
-library for the original API it replaces? How will this affect other projects in
-the Preact ecosystem? Should we coordinate with other projects or libraries?
+> If we implement this proposal, how will existing Preact developers adopt it?
+> Is this a breaking change? Can we write a codemod? Can we provide a runtime
+> adapter library for the original API it replaces? How will this affect other
+> projects in the Preact ecosystem? Should we coordinate with other projects or
+> libraries?
 
 ## How we teach this
 
-What names and terminology work best for these concepts and why? How is this
-idea best presented? As a continuation of existing Preact patterns, or as a
-wholly new one?
-
-Would the acceptance of this proposal mean the Preact documentation must be
-re-organized or altered? Does it change how Preact is taught to new developers
-at any level?
-
-How should this feature be taught to existing Preact developers?
+> How should this feature be taught to existing Preact developers?
+>
+> What names and terminology work best for these concepts and why? How is this
+> idea best presented? As a continuation of existing Preact patterns, or as a
+> wholly new one?
+>
+> Would the acceptance of this proposal mean the Preact documentation must be
+> re-organized or altered? Does it change how Preact is taught to new developers
+> at any level?
 
 ## Unresolved questions
 
-Optional, but suggested for first drafts. What parts of the design are still
-TBD?
+> Optional, but suggested for first drafts. What parts of the design are still
+> TBD?

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ and may be implemented with the goal of eventual inclusion into Preact.
 
 * Fork the RFC repo http://github.com/preactjs/rfcs
 
-* Copy `0000-template.md` to `text/0000-my-feature.md` (where 'my-feature' is
+* Copy `0000-template.md` to `rfcs/0000-my-feature.md` (where 'my-feature' is
   descriptive. Don't assign an RFC number yet).
 
 * Fill in the RFC. Put care into the details: **RFCs that do not present


### PR DESCRIPTION
While working on an RFC I realized it would be nice to have a distinction between what is the default template placeholders and what is the text of my draft. I like to keep the placeholders around as I write my draft so I can refer back to the questions they asked. Svelte uses blockquote syntax for that so I've adopted that here.

Also, changed the `text` folder to be called `rfcs` so it is a little clearer what is stored in this folder.